### PR TITLE
[FIX] Comodel name

### DIFF
--- a/account_due_list_payment_mode/models/account_move_line.py
+++ b/account_due_list_payment_mode/models/account_move_line.py
@@ -10,7 +10,7 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     payment_mode_id = fields.Many2one(
-        comodel_name='payment.mode',
+        comodel_name='account.payment.mode',
         related='invoice_id.payment_mode_id',
         string="Payment Mode",
         store=True,


### PR DESCRIPTION
I had to do this change on 10.0 to work, so I guess the same change is needed for 9.0. I don't have a running instance right now of 9.0 to test it out.